### PR TITLE
Separate install command of nonfree repo and the intel microcode

### DIFF
--- a/src/void-linux/ch01-05-finishing-installation.md
+++ b/src/void-linux/ch01-05-finishing-installation.md
@@ -1,7 +1,12 @@
 # Finishing installation
+## Adding nonfree repository
+```console
+chroot# xbps-install void-repo-nonfree
+```
+
 ## Intel microcode
 ```console
-chroot# xbps-install -Su void-repo-nonfree intel-ucode
+chroot# xbps-install -Su intel-ucode
 ```
 
 > **Note:** If you're using an AMD CPU, install `linux-firmware-amd` instead.


### PR DESCRIPTION
The installation of intel microcode should be done separately after installing the nonfree repository. Otherwise xbps-install will return with an error as it cannot find the intel microcode package.