### PR TITLE
Fixed some stuff

### DIFF
--- a/src/void-linux/ch01-04-inside-the-chroot-jail.md
+++ b/src/void-linux/ch01-04-inside-the-chroot-jail.md
@@ -23,7 +23,7 @@ If you store the appropriate data before creating the fstab file, you don't even
 ```console
 chroot# UEFI_UUID=$(blkid -s UUID -o value /dev/sda1)
 chroot# GRUB_UUID=$(blkid -s UUID -o value /dev/sda2)
-chroot# ROOT_UUID=$(blkid -s UUID -o value /dev/mapper/cryptoroot)
+chroot# ROOT_UUID=$(blkid -s UUID -o value /dev/mapper/cryptroot)
 chroot# cat <<EOF > /etc/fstab
 UUID=$ROOT_UUID / btrfs $BTRFS_OPTS,subvol=@ 0 1
 UUID=$UEFI_UUID /efi vfat defaults,noatime 0 2

--- a/src/void-linux/ch01-05-finishing-installation.md
+++ b/src/void-linux/ch01-05-finishing-installation.md
@@ -17,7 +17,6 @@ In order to have an encrypted swap, let's use a more clean approach by using a _
 _duh_, swap. For this example, I'll create a swapfile of 16 GiB, but you can choose the best size
 for your installation:
 ```console
-chroot# btrfs subvolume create /var/swap
 chroot# truncate -s 0 /var/swap/swapfile
 chroot# chattr +C /var/swap/swapfile
 chroot# btrfs property set /var/swap/swapfile compression none


### PR DESCRIPTION
- Subvolume for swap was already created in previous steps
- Spelling error in /dev/mapper/cryptroot